### PR TITLE
fix HTTP_TIMEOUT initialization, bump version

### DIFF
--- a/lib/cli/version.rb
+++ b/lib/cli/version.rb
@@ -2,6 +2,6 @@ module VMC
   module Cli
     # This version number is used as the RubyGem release version.
     # The internal VMC version number is VMC::VERSION.
-    VERSION = '0.3.18.1'
+    VERSION = '0.3.18.2'
   end
 end

--- a/lib/vmc/client.rb
+++ b/lib/vmc/client.rb
@@ -27,8 +27,7 @@ class VMC::Client
   # Error codes
   VMC_HTTP_ERROR_CODES = [ 400, 500 ]
 
-  HTTP_TIMEOUT = ENV['TIMEOUT'].to_i if ENV['TIMEOUT']
-  HTTP_TIMEOUT ||= 10*60
+  HTTP_TIMEOUT = ENV['TIMEOUT'] ? ENV['TIMEOUT'].to_i : 10*60
   
   # Errors
   class BadTarget <  RuntimeError; end


### PR DESCRIPTION
conditional initialization of constant works differently between ruby versions, so change it to something that works for all.
