### PR TITLE
Add aspdotnet framework support

### DIFF
--- a/lib/cli/frameworks.rb
+++ b/lib/cli/frameworks.rb
@@ -114,8 +114,8 @@ module VMC::Cli
             return Framework.lookup('WSGI')
 
           # .Net
-          elsif !Dir.glob('web.config').empty?
-            return Framework.lookup('dotNet')
+          elsif !Dir.glob('web.config', File::FNM_CASEFOLD).empty?
+            return Framework.lookup('aspdotnet')
 
           # Node.js
           elsif !Dir.glob('*.js').empty?


### PR DESCRIPTION
Adds .NET framework support to CLI tool. 

NOTE: This change is specific to IronFoundry. Previous framework entry `dotNet` is compatible with Uhuru, not IronFoundry.
